### PR TITLE
Decode urlencoded links

### DIFF
--- a/code/bg.js
+++ b/code/bg.js
@@ -100,11 +100,11 @@ function buffer_appendTabInfo(t){
 }
 
 function getTabInfoText(t){
+    url = decodeURI(t.url);
     if (t.title.trim()) {
-        return t.title + '\n' + t.url;
-    } else {
-        return t.url;       
+        url = t.title + '\n' + url;
     }
+    return url;
 }
 
 // function notifyRunning(t){


### PR DESCRIPTION
Decode urlencoded links (such as https://ru.wikipedia.org/wiki/%D0%A2%D0%B5%D1%81%D1%82)